### PR TITLE
Add Vite 7 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       },
       "peerDependencies": {
         "svelte": "4.x || 5.x",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "svelte": "4.x || 5.x",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0 || ^7.0.0"
   },
   "keywords": [
     "svelte",


### PR DESCRIPTION
This fixes the peer dependency warning that appears when installing `markdoc-svelte`.