### PR TITLE
Exclude test files from the built output.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,7 @@ export default [
       typescript({
         sourceMap: true,
         inlineSources: true,
+        exclude: ["**/*.test.ts"],
       }),
       nodeResolve(),
       terser(),


### PR DESCRIPTION
This removes 11 unused files and 8.16 kb from the built package, which makes it 4.4% smaller when installing from npm

Here's the published `dist/test/` directory on npm: https://www.npmjs.com/package/markdoc-svelte/v/3.0.0?activeTab=code

<img width="893" height="582" alt="image" src="https://github.com/user-attachments/assets/97122069-bd4c-410b-b4a6-a5758fb8b266" />
